### PR TITLE
Improved the error message when the call to the parent class construc…

### DIFF
--- a/runtime/nutterfixture.py
+++ b/runtime/nutterfixture.py
@@ -54,6 +54,9 @@ class NutterFixture(object):
         return TestExecResults(self.test_results)
 
     def __load_fixture(self):
+        if hasattr(self, 'data_loader') == False:
+            raise InitializationException("If you have an __init__ method in your test class, make sure you make a call to initialize the parent class.  For example: NutterFixture.init(self)")
+
         test_case_dict = self.data_loader.load_fixture(self)
         if test_case_dict is None:
             logging.fatal("Invalid Test Fixture")
@@ -72,4 +75,9 @@ class NutterFixture(object):
 
 
 class InvalidTestFixtureException(Exception):
-    pass
+    def __init__(self, message):
+        super().__init__(message)
+
+class InitializationException(Exception):
+    def __init__(self, message):
+        super().__init__(message)

--- a/runtime/nutterfixture.py
+++ b/runtime/nutterfixture.py
@@ -55,7 +55,8 @@ class NutterFixture(object):
 
     def __load_fixture(self):
         if hasattr(self, 'data_loader') == False:
-            raise InitializationException("If you have an __init__ method in your test class, make sure you make a call to initialize the parent class.  For example: NutterFixture.init(self)")
+            raise InitializationException("If you have an __init__ method in your test class, make sure you make a call to initialize the parent class.  For example: super().__init__()")
+
 
         test_case_dict = self.data_loader.load_fixture(self)
         if test_case_dict is None:

--- a/tests/runtime/test_nutterfixture.py
+++ b/tests/runtime/test_nutterfixture.py
@@ -4,7 +4,7 @@ Licensed under the MIT license.
 """
 
 import pytest
-from runtime.nutterfixture import NutterFixture, tag, InvalidTestFixtureException
+from runtime.nutterfixture import NutterFixture, tag, InvalidTestFixtureException, InitializationException
 from runtime.testcase import TestCase
 from runtime.fixtureloader import FixtureLoader
 from common.testresult  import TestResult, TestResults
@@ -239,6 +239,14 @@ def test__execute_tests__test_names_not_in_order_in_class__tests_executed_in_alp
     # Assert
     assert '1wxyz' == fix.get_method_order()
 
+def test__execute_tests__subclass_init_does_not_call_NutterFixture_init__throws_InitializationException():
+    # Arrange
+    fix = TestFixtureThatDoesNotCallBaseCtor()
+
+    # Act
+    with pytest.raises(InitializationException):
+        fix.execute_tests()
+
 def test__run_test_method__has_list_tag_decorator__list_set_on_method():
     # Arrange
     class Wrapper(NutterFixture):
@@ -376,3 +384,10 @@ class OutOfOrderTestFixture(NutterFixture):
     
     def get_method_order(self):
         return self.__method_order
+
+class TestFixtureThatDoesNotCallBaseCtor(NutterFixture):
+    def __init__(self):
+        pass
+
+    def assertion_test_case(self):
+        assert 1 == 1


### PR DESCRIPTION
Improved the error message when the call to the parent class constructor is missing in a test fixture.

NutterFixture will now raise an InitializationException with a message: If you have an __init__ method in your test class, make sure you make a call to initialize the parent class.  For example: NutterFixture.init(self).

NutterFixture will determine this is the issue when execute_tests is called, but the instance variable data_loader has not been set.  That variable is set in the NutterFixture base class constructor.

Closes #16 