### PR TITLE
Feature: Discover test files with '_test' suffix

### DIFF
--- a/cli/nuttercli.py
+++ b/cli/nuttercli.py
@@ -141,7 +141,7 @@ class NutterCLI(object):
         segments = pattern.split('/')
         if len(segments) > 0:
             search_pattern = segments[len(segments)-1]
-            if search_pattern.lower().startswith('test_'):
+            if search_pattern.lower().startswith('test_') or search_pattern.lower().endswith('_test'):
                 return False
             return True
         logging.Fatal(

--- a/cli/nuttercli.py
+++ b/cli/nuttercli.py
@@ -141,7 +141,7 @@ class NutterCLI(object):
         segments = pattern.split('/')
         if len(segments) > 0:
             search_pattern = segments[len(segments)-1]
-            if search_pattern.lower().startswith('test_') or search_pattern.lower().endswith('_test'):
+            if api.TestNotebook._is_valid_test_name(search_pattern):
                 return False
             return True
         logging.Fatal(

--- a/common/api.py
+++ b/common/api.py
@@ -212,7 +212,10 @@ class TestNotebook(object):
 
         self.name = name
         self.path = path
-        self.test_name = name.split("_")[1]
+        if name.lower().startswith('test_'):
+            self.test_name = name.split("_")[1]
+        if name.lower().endswith('_test'):
+            self.test_name = name.split("_")[0]
 
     def __eq__(self, obj):
         is_equal = obj.name == self.name and obj.path == self.path
@@ -230,7 +233,7 @@ class TestNotebook(object):
         if name is None:
             return False
 
-        return name.lower().startswith('test_')
+        return name.lower().startswith('test_') or name.lower().endswith('_test')
 
     @classmethod
     def _get_notebook_name_from_path(cls, path):

--- a/common/api.py
+++ b/common/api.py
@@ -212,14 +212,17 @@ class TestNotebook(object):
 
         self.name = name
         self.path = path
-        if name.lower().startswith('test_'):
-            self.test_name = name.split("_")[1]
-        if name.lower().endswith('_test'):
-            self.test_name = name.split("_")[0]
+        self.test_name = self.get_test_name(name)
 
     def __eq__(self, obj):
         is_equal = obj.name == self.name and obj.path == self.path
         return isinstance(obj, TestNotebook) and is_equal
+    
+    def get_test_name(self, name):
+        if name.lower().startswith('test_'):
+            return name.split("_")[1]
+        if name.lower().endswith('_test'):
+            return name.split("_")[0]
 
     @classmethod
     def from_path(cls, path):

--- a/common/apiclientresults.py
+++ b/common/apiclientresults.py
@@ -6,6 +6,7 @@ Licensed under the MIT license.
 from . import utils
 from abc import ABCMeta
 from .testresult import TestResults
+import common.api as api
 import logging
 
 
@@ -156,13 +157,7 @@ class NotebookObject(WorkspaceObject):
 
     @property
     def is_test_notebook(self):
-        return self._is_valid_test_name(self.name)
-
-    def _is_valid_test_name(self, name):
-        if name is None:
-            return False
-
-        return name.lower().startswith('test_') or name.lower().endswith('_test')
+        return api.TestNotebook._is_valid_test_name(self.name)
 
 
 class Directory(WorkspaceObject):

--- a/common/apiclientresults.py
+++ b/common/apiclientresults.py
@@ -162,7 +162,7 @@ class NotebookObject(WorkspaceObject):
         if name is None:
             return False
 
-        return name.lower().startswith('test_')
+        return name.lower().startswith('test_') or name.lower().endswith('_test')
 
 
 class Directory(WorkspaceObject):

--- a/tests/nutter/test_api.py
+++ b/tests/nutter/test_api.py
@@ -48,6 +48,22 @@ def test__list_tests__onetest__okay(mocker):
     assert len(tests) == 1
     assert tests[0] == TestNotebook('test_mynotebook', '/test_mynotebook')
 
+def test__list_suffix_tests__onetest__okay(mocker):
+
+    nutter = _get_nutter(mocker)
+    dbapi_client = _get_client(mocker)
+    nutter.dbclient = dbapi_client
+    mocker.patch.object(nutter.dbclient, 'list_objects')
+
+    workspace_path_1 = _get_workspacepathobject(
+        [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/mynotebook_test')])
+
+    nutter.dbclient.list_objects.return_value = workspace_path_1
+
+    tests = nutter.list_tests("/")
+
+    assert len(tests) == 1
+    assert tests[0] == TestNotebook('mynotebook_test', '/mynotebook_test')
 
 def test__list_tests__onetest_in_folder__okay(mocker):
 
@@ -67,6 +83,23 @@ def test__list_tests__onetest_in_folder__okay(mocker):
     assert tests[0] == TestNotebook(
         'test_mynotebook', '/folder/test_mynotebook')
 
+def test__list_suffix_tests__onetest_in_folder__okay(mocker):
+
+    nutter = _get_nutter(mocker)
+    dbapi_client = _get_client(mocker)
+    nutter.dbclient = dbapi_client
+    mocker.patch.object(nutter.dbclient, 'list_objects')
+
+    workspace_path_1 = _get_workspacepathobject(
+        [('NOTEBOOK', '/folder/mynotebook'), ('NOTEBOOK', '/folder/mynotebook_test')])
+
+    nutter.dbclient.list_objects.return_value = workspace_path_1
+
+    tests = nutter.list_tests("/folder")
+
+    assert len(tests) == 1
+    assert tests[0] == TestNotebook(
+        'mynotebook_test', '/folder/mynotebook_test')
 
 @pytest.mark.skip('No longer needed')
 def test__list_tests__response_without_root_object__okay(mocker):
@@ -105,6 +138,23 @@ def test__list_tests__onetest_uppercase_name__okay(mocker):
 
     assert len(tests) == 1
     assert tests == [TestNotebook('TEST_mynote', '/TEST_mynote')]
+
+def test__list_suffix_tests__onetest_uppercase_name__okay(mocker):
+
+    nutter = _get_nutter(mocker)
+    dbapi_client = _get_client(mocker)
+    nutter.dbclient = dbapi_client
+    mocker.patch.object(nutter.dbclient, 'list_objects')
+
+    workspace_path_1 = _get_workspacepathobject(
+        [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/mynote_TEST')])
+
+    nutter.dbclient.list_objects.return_value = workspace_path_1
+
+    tests = nutter.list_tests("/")
+
+    assert len(tests) == 1
+    assert tests == [TestNotebook('mynote_TEST', '/mynote_TEST')]
 
 
 def test__list_tests__nutterstatusevents_testlisting_sequence_is_fired(mocker):
@@ -147,6 +197,26 @@ def test__list_tests_recursively__1test1dir1test__2_tests(mocker):
     assert expected == tests
     assert nutter.dbclient.list_objects.call_count == 2
 
+def test__list_suffix_tests_recursively__1test1dir1test__2_tests(mocker):
+    nutter = _get_nutter(mocker)
+    dbapi_client = _get_client(mocker)
+    nutter.dbclient = dbapi_client
+    mocker.patch.object(nutter.dbclient, 'list_objects')
+
+    workspace_path_1 = _get_workspacepathobject(
+        [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
+    workspace_path_2 = _get_workspacepathobject([('NOTEBOOK', '/p/1_test')])
+
+    nutter.dbclient.list_objects.side_effect = [
+        workspace_path_1, workspace_path_2]
+
+    tests = nutter.list_tests("/", True)
+
+    expected = [TestNotebook('1_test', '/1_test'),
+                TestNotebook('1_test', '/p/1_test')]
+    assert expected == tests
+    assert nutter.dbclient.list_objects.call_count == 2
+
 
 def test__list_tests_recursively__1test1dir2test__3_tests(mocker):
     nutter = _get_nutter(mocker)
@@ -168,6 +238,26 @@ def test__list_tests_recursively__1test1dir2test__3_tests(mocker):
     assert expected == tests
     assert nutter.dbclient.list_objects.call_count == 2
 
+def test__list_suffix_tests_recursively__1test1dir2test__3_tests(mocker):
+    nutter = _get_nutter(mocker)
+    dbapi_client = _get_client(mocker)
+    nutter.dbclient = dbapi_client
+    mocker.patch.object(nutter.dbclient, 'list_objects')
+
+    workspace_path_1 = _get_workspacepathobject(
+        [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
+    workspace_path_2 = _get_workspacepathobject(
+        [('NOTEBOOK', '/p/1_test'), ('NOTEBOOK', '/p/2_test')])
+
+    nutter.dbclient.list_objects.side_effect = [
+        workspace_path_1, workspace_path_2]
+
+    tests = nutter.list_tests("/", True)
+    expected = [TestNotebook('1_test', '/1_test'), TestNotebook('1_test',
+                                                                '/p/1_test'), TestNotebook('2_test', '/p/2_test')]
+    assert expected == tests
+    assert nutter.dbclient.list_objects.call_count == 2
+
 
 def test__list_tests_recursively__1test1dir1dir__1_test(mocker):
     nutter = _get_nutter(mocker)
@@ -186,6 +276,26 @@ def test__list_tests_recursively__1test1dir1dir__1_test(mocker):
     tests = nutter.list_tests("/", True)
 
     expected = [TestNotebook('test_1', '/test_1')]
+    assert expected == tests
+    assert nutter.dbclient.list_objects.call_count == 3
+
+def test__list_suffix_tests_recursively__1test1dir1dir__1_test(mocker):
+    nutter = _get_nutter(mocker)
+    dbapi_client = _get_client(mocker)
+    nutter.dbclient = dbapi_client
+    mocker.patch.object(nutter.dbclient, 'list_objects')
+
+    workspace_path_1 = _get_workspacepathobject(
+        [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
+    workspace_path_2 = _get_workspacepathobject([('DIRECTORY', '/p/c')])
+    workspace_path_3 = _get_workspacepathobject([])
+
+    nutter.dbclient.list_objects.side_effect = [
+        workspace_path_1, workspace_path_2, workspace_path_3]
+
+    tests = nutter.list_tests("/", True)
+
+    expected = [TestNotebook('1_test', '/1_test')]
     assert expected == tests
     assert nutter.dbclient.list_objects.call_count == 3
 
@@ -244,6 +354,47 @@ def test__run_tests__onematch_two_tests___nutterstatusevents_testlisting_schedul
     assert status_event.event == NutterStatusEvents.TestExecutionResult
     assert status_event.data #True if success
 
+def test__run_suffix_tests__onematch_two_tests___nutterstatusevents_testlisting_scheduling_execution_sequence_is_fired(mocker):
+    event_handler = TestEventHandler()
+    nutter = _get_nutter(mocker, event_handler)
+    test_results = TestResults()
+    test_results.append(TestResult('case',True, 10,[]))
+    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', test_results.serialize())
+    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+
+    nutter.dbclient = dbapi_client
+    _mock_dbclient_list_objects(mocker, dbapi_client, [(
+        'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/abc_test')])
+
+    results = nutter.run_tests("/my*", "cluster")
+
+    status_event = event_handler.get_item()
+    assert status_event.event == NutterStatusEvents.TestExecutionRequest
+    assert status_event.data == '/my*'
+
+    status_event = event_handler.get_item()
+    assert status_event.event == NutterStatusEvents.TestsListing
+
+    status_event = event_handler.get_item()
+    assert status_event.event == NutterStatusEvents.TestsListingResults
+    assert status_event.data == 2
+
+    status_event = event_handler.get_item()
+    assert status_event.event == NutterStatusEvents.TestsListingFiltered
+    assert status_event.data == 1
+
+    status_event = event_handler.get_item()
+    assert status_event.event == NutterStatusEvents.TestScheduling
+    assert status_event.data == '/my_test'
+
+    status_event = event_handler.get_item()
+    assert status_event.event == NutterStatusEvents.TestExecuted
+    assert status_event.data.success
+
+    status_event = event_handler.get_item()
+    assert status_event.event == NutterStatusEvents.TestExecutionResult
+    assert status_event.data #True if success
+
 
 def test__run_tests__onematch__okay(mocker):
     nutter = _get_nutter(mocker)
@@ -253,6 +404,21 @@ def test__run_tests__onematch__okay(mocker):
     nutter.dbclient = dbapi_client
     _mock_dbclient_list_objects(mocker, dbapi_client, [(
         'NOTEBOOK', '/test_my'), ('NOTEBOOK', '/my')])
+
+    results = nutter.run_tests("/my*", "cluster")
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.task_result_state == 'TERMINATED'
+
+def test__run_suffix_tests__onematch__okay(mocker):
+    nutter = _get_nutter(mocker)
+    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+
+    nutter.dbclient = dbapi_client
+    _mock_dbclient_list_objects(mocker, dbapi_client, [(
+        'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my')])
 
     results = nutter.run_tests("/my*", "cluster")
 
@@ -272,6 +438,25 @@ def test__run_tests_recursively__1test1dir2test__3_tests(mocker):
         [('NOTEBOOK', '/test_1'), ('DIRECTORY', '/p')])
     workspace_path_2 = _get_workspacepathobject(
         [('NOTEBOOK', '/p/test_1'), ('NOTEBOOK', '/p/test_2')])
+
+    nutter.dbclient.list_objects.side_effect = [
+        workspace_path_1, workspace_path_2]
+
+    tests = nutter.run_tests('/','cluster', 120, 1, True)
+    assert len(tests) == 3
+
+def test__run_suffix_tests_recursively__1test1dir2test__3_tests(mocker):
+    nutter = _get_nutter(mocker)
+    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+    nutter.dbclient = dbapi_client
+
+    mocker.patch.object(nutter.dbclient, 'list_objects')
+
+    workspace_path_1 = _get_workspacepathobject(
+        [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
+    workspace_path_2 = _get_workspacepathobject(
+        [('NOTEBOOK', '/p/test_1'), ('NOTEBOOK', '/p/2_test')])
 
     nutter.dbclient.list_objects.side_effect = [
         workspace_path_1, workspace_path_2]
@@ -300,6 +485,27 @@ def test__run_tests_recursively__1dir1dir2test__2_tests(mocker):
     tests = nutter.run_tests('/','cluster', 120, 1, True)
     assert len(tests) == 2
 
+def test__run_suffix_tests_recursively__1dir1dir2test__2_tests(mocker):
+    nutter = _get_nutter(mocker)
+    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+    nutter.dbclient = dbapi_client
+
+    mocker.patch.object(nutter.dbclient, 'list_objects')
+
+    workspace_path_1 = _get_workspacepathobject(
+        [('DIRECTORY', '/p')])
+    workspace_path_2 = _get_workspacepathobject(
+        [('DIRECTORY', '/c')])
+    workspace_path_3 = _get_workspacepathobject(
+        [('NOTEBOOK', '/p/c/1_test'), ('NOTEBOOK', '/p/c/2_test')])
+
+    nutter.dbclient.list_objects.side_effect = [
+        workspace_path_1, workspace_path_2, workspace_path_3]
+
+    tests = nutter.run_tests('/','cluster', 120, 1, True)
+    assert len(tests) == 2
+
 def test__run_tests__onematch_suffix_is_uppercase__okay(mocker):
     nutter = _get_nutter(mocker)
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
@@ -308,6 +514,20 @@ def test__run_tests__onematch_suffix_is_uppercase__okay(mocker):
     nutter.dbclient = dbapi_client
     _mock_dbclient_list_objects(mocker, dbapi_client, [(
         'NOTEBOOK', '/TEST_my'), ('NOTEBOOK', '/my')])
+
+    results = nutter.run_tests("/my*", "cluster")
+
+    assert len(results) == 1
+    assert results[0].task_result_state == 'TERMINATED'
+
+def test__run_suffix_tests__onematch_suffix_is_uppercase__okay(mocker):
+    nutter = _get_nutter(mocker)
+    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+
+    nutter.dbclient = dbapi_client
+    _mock_dbclient_list_objects(mocker, dbapi_client, [(
+        'NOTEBOOK', '/my_TEST'), ('NOTEBOOK', '/my')])
 
     results = nutter.run_tests("/my*", "cluster")
 
@@ -323,6 +543,19 @@ def test__run_tests__nomatch_case_sensitive__okay(mocker):
     nutter.dbclient = dbapi_client
     _mock_dbclient_list_objects(mocker, dbapi_client, [(
         'NOTEBOOK', '/test_MY'), ('NOTEBOOK', '/my')])
+
+    results = nutter.run_tests("/my*", "cluster")
+
+    assert len(results) == 0
+
+def test__run_suffix_tests__nomatch_case_sensitive__okay(mocker):
+    nutter = _get_nutter(mocker)
+    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+
+    nutter.dbclient = dbapi_client
+    _mock_dbclient_list_objects(mocker, dbapi_client, [(
+        'NOTEBOOK', '/MY_test'), ('NOTEBOOK', '/my')])
 
     results = nutter.run_tests("/my*", "cluster")
 
@@ -344,6 +577,20 @@ def test__run_tests__twomatches_with_pattern__okay(mocker):
     assert results[0].task_result_state == 'TERMINATED'
     assert results[1].task_result_state == 'TERMINATED'
 
+def test__run_suffix_tests__twomatches_with_pattern__okay(mocker):
+    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+
+    nutter = _get_nutter(mocker)
+    nutter.dbclient = dbapi_client
+    _mock_dbclient_list_objects(mocker, dbapi_client, [(
+        'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my2_test')])
+
+    results = nutter.run_tests("/my*", "cluster")
+
+    assert len(results) == 2
+    assert results[0].task_result_state == 'TERMINATED'
+    assert results[1].task_result_state == 'TERMINATED'
 
 def test__run_tests__with_invalid_pattern__valueerror(mocker):
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
@@ -358,13 +605,24 @@ def test__run_tests__with_invalid_pattern__valueerror(mocker):
 
 
 def test__run_tests__nomatches__okay(mocker):
-
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
     nutter = _get_nutter(mocker)
     nutter.dbclient = dbapi_client
     _mock_dbclient_list_objects(mocker, dbapi_client, [(
         'NOTEBOOK', '/test_my'), ('NOTEBOOK', '/test_my2')])
+
+    results = nutter.run_tests("/abc*", "cluster")
+
+    assert len(results) == 0
+
+def test__run_suffix_tests__nomatches__okay(mocker):
+    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+    nutter = _get_nutter(mocker)
+    nutter.dbclient = dbapi_client
+    _mock_dbclient_list_objects(mocker, dbapi_client, [(
+        'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my2_test')])
 
     results = nutter.run_tests("/abc*", "cluster")
 
@@ -435,10 +693,15 @@ def test__testnamepatternmatcher_ctor_valid_regex_pattern__pattern_is_pattern(pa
 filter_patterns = [
     ('', [], 0),
     ('a', [TestNotebook("test_a", "/test_a")], 1),
+    ('a', [TestNotebook("a_test", "/a_test")], 1),
     ('*', [TestNotebook("test_a", "/test_a"), TestNotebook("test_b", "/test_b")], 2),
+    ('*', [TestNotebook("a_test", "/a_test"), TestNotebook("b_test", "/b_test")], 2),
     ('b*',[TestNotebook("test_a", "/test_a"), TestNotebook("test_b", "/test_b")], 1),
+    ('b*',[TestNotebook("a_test", "/a_test"), TestNotebook("b_test", "/b_test")], 1),
     ('b*',[TestNotebook("test_ba", "/test_ba"), TestNotebook("test_b", "/test_b")], 2),
+    ('b*',[TestNotebook("ba_test", "/ba_test"), TestNotebook("b_test", "/b_test")], 2),
     ('c*',[TestNotebook("test_a", "/test_a"), TestNotebook("test_b", "/test_b")], 0),
+    ('c*',[TestNotebook("a_test", "/a_test"), TestNotebook("b_test", "/b_test")], 0),
 ]
 @pytest.mark.parametrize('pattern, list_results, expected_count', filter_patterns)
 def test__filter_by_pattern__valid_scenarios__result_len_is_expected_count(pattern, list_results, expected_count):

--- a/tests/nutter/test_api.py
+++ b/tests/nutter/test_api.py
@@ -31,7 +31,7 @@ def test__get_report_writer__tagsreportwriter__valid_instance():
     assert isinstance(writer, TagsReportWriter)
 
 
-def test__list_tests__onetest__okay(mocker):
+def test__list_tests__twotest__okay(mocker):
 
     nutter = _get_nutter(mocker)
     dbapi_client = _get_client(mocker)
@@ -39,16 +39,34 @@ def test__list_tests__onetest__okay(mocker):
     mocker.patch.object(nutter.dbclient, 'list_objects')
 
     workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/test_mynotebook')])
+        [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/test_mynotebook'), ('NOTEBOOK', '/mynotebook_test')])
 
     nutter.dbclient.list_objects.return_value = workspace_path_1
 
     tests = nutter.list_tests("/")
 
-    assert len(tests) == 1
+    assert len(tests) == 2
     assert tests[0] == TestNotebook('test_mynotebook', '/test_mynotebook')
+    assert tests[1] == TestNotebook('mynotebook_test', '/mynotebook_test')
 
-def test__list_suffix_tests__onetest__okay(mocker):
+# def test__list_suffix_tests__onetest__okay(mocker):
+
+#     nutter = _get_nutter(mocker)
+#     dbapi_client = _get_client(mocker)
+#     nutter.dbclient = dbapi_client
+#     mocker.patch.object(nutter.dbclient, 'list_objects')
+
+#     workspace_path_1 = _get_workspacepathobject(
+#         [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/mynotebook_test')])
+
+#     nutter.dbclient.list_objects.return_value = workspace_path_1
+
+#     tests = nutter.list_tests("/")
+
+#     assert len(tests) == 1
+#     assert tests[0] == TestNotebook('mynotebook_test', '/mynotebook_test')
+
+def test__list_tests__twotest_in_folder__okay(mocker):
 
     nutter = _get_nutter(mocker)
     dbapi_client = _get_client(mocker)
@@ -56,50 +74,35 @@ def test__list_suffix_tests__onetest__okay(mocker):
     mocker.patch.object(nutter.dbclient, 'list_objects')
 
     workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/mynotebook_test')])
-
-    nutter.dbclient.list_objects.return_value = workspace_path_1
-
-    tests = nutter.list_tests("/")
-
-    assert len(tests) == 1
-    assert tests[0] == TestNotebook('mynotebook_test', '/mynotebook_test')
-
-def test__list_tests__onetest_in_folder__okay(mocker):
-
-    nutter = _get_nutter(mocker)
-    dbapi_client = _get_client(mocker)
-    nutter.dbclient = dbapi_client
-    mocker.patch.object(nutter.dbclient, 'list_objects')
-
-    workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/folder/mynotebook'), ('NOTEBOOK', '/folder/test_mynotebook')])
+        [('NOTEBOOK', '/folder/mynotebook'), ('NOTEBOOK', '/folder/test_mynotebook'), ('NOTEBOOK', '/folder/mynotebook_test')])
 
     nutter.dbclient.list_objects.return_value = workspace_path_1
 
     tests = nutter.list_tests("/folder")
 
-    assert len(tests) == 1
+    assert len(tests) == 2
     assert tests[0] == TestNotebook(
         'test_mynotebook', '/folder/test_mynotebook')
-
-def test__list_suffix_tests__onetest_in_folder__okay(mocker):
-
-    nutter = _get_nutter(mocker)
-    dbapi_client = _get_client(mocker)
-    nutter.dbclient = dbapi_client
-    mocker.patch.object(nutter.dbclient, 'list_objects')
-
-    workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/folder/mynotebook'), ('NOTEBOOK', '/folder/mynotebook_test')])
-
-    nutter.dbclient.list_objects.return_value = workspace_path_1
-
-    tests = nutter.list_tests("/folder")
-
-    assert len(tests) == 1
-    assert tests[0] == TestNotebook(
+    assert tests[1] == TestNotebook(
         'mynotebook_test', '/folder/mynotebook_test')
+
+# def test__list_suffix_tests__onetest_in_folder__okay(mocker):
+
+#     nutter = _get_nutter(mocker)
+#     dbapi_client = _get_client(mocker)
+#     nutter.dbclient = dbapi_client
+#     mocker.patch.object(nutter.dbclient, 'list_objects')
+
+#     workspace_path_1 = _get_workspacepathobject(
+#         [('NOTEBOOK', '/folder/mynotebook'), ('NOTEBOOK', '/folder/mynotebook_test')])
+
+#     nutter.dbclient.list_objects.return_value = workspace_path_1
+
+#     tests = nutter.list_tests("/folder")
+
+#     assert len(tests) == 1
+#     assert tests[0] == TestNotebook(
+#         'mynotebook_test', '/folder/mynotebook_test')
 
 @pytest.mark.skip('No longer needed')
 def test__list_tests__response_without_root_object__okay(mocker):
@@ -122,7 +125,7 @@ def test__list_tests__response_without_root_object__okay(mocker):
     assert tests[0] == TestNotebook('test_mynotebook', '/test_mynotebook')
 
 
-def test__list_tests__onetest_uppercase_name__okay(mocker):
+def test__list_tests__twotest_uppercase_name__okay(mocker):
 
     nutter = _get_nutter(mocker)
     dbapi_client = _get_client(mocker)
@@ -130,31 +133,31 @@ def test__list_tests__onetest_uppercase_name__okay(mocker):
     mocker.patch.object(nutter.dbclient, 'list_objects')
 
     workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/TEST_mynote')])
+        [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/TEST_mynote'), ('NOTEBOOK', '/mynote_TEST')])
 
     nutter.dbclient.list_objects.return_value = workspace_path_1
 
     tests = nutter.list_tests("/")
 
-    assert len(tests) == 1
-    assert tests == [TestNotebook('TEST_mynote', '/TEST_mynote')]
+    assert len(tests) == 2
+    assert tests == [TestNotebook('TEST_mynote', '/TEST_mynote'), TestNotebook('mynote_TEST', '/mynote_TEST')]
 
-def test__list_suffix_tests__onetest_uppercase_name__okay(mocker):
+# def test__list_suffix_tests__onetest_uppercase_name__okay(mocker):
 
-    nutter = _get_nutter(mocker)
-    dbapi_client = _get_client(mocker)
-    nutter.dbclient = dbapi_client
-    mocker.patch.object(nutter.dbclient, 'list_objects')
+#     nutter = _get_nutter(mocker)
+#     dbapi_client = _get_client(mocker)
+#     nutter.dbclient = dbapi_client
+#     mocker.patch.object(nutter.dbclient, 'list_objects')
 
-    workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/mynote_TEST')])
+#     workspace_path_1 = _get_workspacepathobject(
+#         [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/mynote_TEST')])
 
-    nutter.dbclient.list_objects.return_value = workspace_path_1
+#     nutter.dbclient.list_objects.return_value = workspace_path_1
 
-    tests = nutter.list_tests("/")
+#     tests = nutter.list_tests("/")
 
-    assert len(tests) == 1
-    assert tests == [TestNotebook('mynote_TEST', '/mynote_TEST')]
+#     assert len(tests) == 1
+#     assert tests == [TestNotebook('mynote_TEST', '/mynote_TEST')]
 
 
 def test__list_tests__nutterstatusevents_testlisting_sequence_is_fired(mocker):
@@ -165,7 +168,7 @@ def test__list_tests__nutterstatusevents_testlisting_sequence_is_fired(mocker):
     mocker.patch.object(nutter.dbclient, 'list_objects')
 
     workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/TEST_mynote')])
+        [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/TEST_mynote'), ('NOTEBOOK', '/mynote_TEST')])
 
     nutter.dbclient.list_objects.return_value = workspace_path_1
 
@@ -175,48 +178,7 @@ def test__list_tests__nutterstatusevents_testlisting_sequence_is_fired(mocker):
 
     status_event = event_handler.get_item()
     assert status_event.event == NutterStatusEvents.TestsListingResults
-    assert status_event.data == 1
-
-def test__list_tests_recursively__1test1dir1test__2_tests(mocker):
-    nutter = _get_nutter(mocker)
-    dbapi_client = _get_client(mocker)
-    nutter.dbclient = dbapi_client
-    mocker.patch.object(nutter.dbclient, 'list_objects')
-
-    workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/test_1'), ('DIRECTORY', '/p')])
-    workspace_path_2 = _get_workspacepathobject([('NOTEBOOK', '/p/test_1')])
-
-    nutter.dbclient.list_objects.side_effect = [
-        workspace_path_1, workspace_path_2]
-
-    tests = nutter.list_tests("/", True)
-
-    expected = [TestNotebook('test_1', '/test_1'),
-                TestNotebook('test_1', '/p/test_1')]
-    assert expected == tests
-    assert nutter.dbclient.list_objects.call_count == 2
-
-def test__list_suffix_tests_recursively__1test1dir1test__2_tests(mocker):
-    nutter = _get_nutter(mocker)
-    dbapi_client = _get_client(mocker)
-    nutter.dbclient = dbapi_client
-    mocker.patch.object(nutter.dbclient, 'list_objects')
-
-    workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
-    workspace_path_2 = _get_workspacepathobject([('NOTEBOOK', '/p/1_test')])
-
-    nutter.dbclient.list_objects.side_effect = [
-        workspace_path_1, workspace_path_2]
-
-    tests = nutter.list_tests("/", True)
-
-    expected = [TestNotebook('1_test', '/1_test'),
-                TestNotebook('1_test', '/p/1_test')]
-    assert expected == tests
-    assert nutter.dbclient.list_objects.call_count == 2
-
+    assert status_event.data == 2
 
 def test__list_tests_recursively__1test1dir2test__3_tests(mocker):
     nutter = _get_nutter(mocker)
@@ -226,6 +188,47 @@ def test__list_tests_recursively__1test1dir2test__3_tests(mocker):
 
     workspace_path_1 = _get_workspacepathobject(
         [('NOTEBOOK', '/test_1'), ('DIRECTORY', '/p')])
+    workspace_path_2 = _get_workspacepathobject([('NOTEBOOK', '/p/test_1'), ('NOTEBOOK', '/p/2_test')])
+
+    nutter.dbclient.list_objects.side_effect = [workspace_path_1, workspace_path_2]
+
+    tests = nutter.list_tests("/", True)
+
+    expected = [TestNotebook('test_1', '/test_1'),
+                TestNotebook('test_1', '/p/test_1'),
+                TestNotebook('2_test', '/p/2_test')]
+    assert expected == tests
+    assert nutter.dbclient.list_objects.call_count == 2
+
+# def test__list_suffix_tests_recursively__1test1dir1test__2_tests(mocker):
+#     nutter = _get_nutter(mocker)
+#     dbapi_client = _get_client(mocker)
+#     nutter.dbclient = dbapi_client
+#     mocker.patch.object(nutter.dbclient, 'list_objects')
+
+#     workspace_path_1 = _get_workspacepathobject(
+#         [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
+#     workspace_path_2 = _get_workspacepathobject([('NOTEBOOK', '/p/1_test')])
+
+#     nutter.dbclient.list_objects.side_effect = [
+#         workspace_path_1, workspace_path_2]
+
+#     tests = nutter.list_tests("/", True)
+
+#     expected = [TestNotebook('1_test', '/1_test'),
+#                 TestNotebook('1_test', '/p/1_test')]
+#     assert expected == tests
+#     assert nutter.dbclient.list_objects.call_count == 2
+
+
+def test__list_tests_recursively__2test1dir2test__4_tests(mocker):
+    nutter = _get_nutter(mocker)
+    dbapi_client = _get_client(mocker)
+    nutter.dbclient = dbapi_client
+    mocker.patch.object(nutter.dbclient, 'list_objects')
+
+    workspace_path_1 = _get_workspacepathobject(
+        [('NOTEBOOK', '/test_1'), ('NOTEBOOK', '/3_test'), ('DIRECTORY', '/p')])
     workspace_path_2 = _get_workspacepathobject(
         [('NOTEBOOK', '/p/test_1'), ('NOTEBOOK', '/p/test_2')])
 
@@ -233,40 +236,44 @@ def test__list_tests_recursively__1test1dir2test__3_tests(mocker):
         workspace_path_1, workspace_path_2]
 
     tests = nutter.list_tests("/", True)
-    expected = [TestNotebook('test_1', '/test_1'), TestNotebook('test_1',
-                                                                '/p/test_1'), TestNotebook('test_2', '/p/test_2')]
+    print(tests)
+    expected = [TestNotebook('test_1', '/test_1'),
+                TestNotebook('3_test', '/3_test'),
+                TestNotebook('test_1', '/p/test_1'),
+                TestNotebook('test_2', '/p/test_2')]
+
     assert expected == tests
     assert nutter.dbclient.list_objects.call_count == 2
 
-def test__list_suffix_tests_recursively__1test1dir2test__3_tests(mocker):
+# def test__list_suffix_tests_recursively__1test1dir2test__3_tests(mocker):
+#     nutter = _get_nutter(mocker)
+#     dbapi_client = _get_client(mocker)
+#     nutter.dbclient = dbapi_client
+#     mocker.patch.object(nutter.dbclient, 'list_objects')
+
+#     workspace_path_1 = _get_workspacepathobject(
+#         [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
+#     workspace_path_2 = _get_workspacepathobject(
+#         [('NOTEBOOK', '/p/1_test'), ('NOTEBOOK', '/p/2_test')])
+
+#     nutter.dbclient.list_objects.side_effect = [
+#         workspace_path_1, workspace_path_2]
+
+#     tests = nutter.list_tests("/", True)
+#     expected = [TestNotebook('1_test', '/1_test'), TestNotebook('1_test',
+#                                                                 '/p/1_test'), TestNotebook('2_test', '/p/2_test')]
+#     assert expected == tests
+#     assert nutter.dbclient.list_objects.call_count == 2
+
+
+def test__list_tests_recursively__1test1test1dir1dir__2_test(mocker):
     nutter = _get_nutter(mocker)
     dbapi_client = _get_client(mocker)
     nutter.dbclient = dbapi_client
     mocker.patch.object(nutter.dbclient, 'list_objects')
 
     workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
-    workspace_path_2 = _get_workspacepathobject(
-        [('NOTEBOOK', '/p/1_test'), ('NOTEBOOK', '/p/2_test')])
-
-    nutter.dbclient.list_objects.side_effect = [
-        workspace_path_1, workspace_path_2]
-
-    tests = nutter.list_tests("/", True)
-    expected = [TestNotebook('1_test', '/1_test'), TestNotebook('1_test',
-                                                                '/p/1_test'), TestNotebook('2_test', '/p/2_test')]
-    assert expected == tests
-    assert nutter.dbclient.list_objects.call_count == 2
-
-
-def test__list_tests_recursively__1test1dir1dir__1_test(mocker):
-    nutter = _get_nutter(mocker)
-    dbapi_client = _get_client(mocker)
-    nutter.dbclient = dbapi_client
-    mocker.patch.object(nutter.dbclient, 'list_objects')
-
-    workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/test_1'), ('DIRECTORY', '/p')])
+        [('NOTEBOOK', '/test_1'), ('NOTEBOOK', '/2_test'), ('DIRECTORY', '/p')])
     workspace_path_2 = _get_workspacepathobject([('DIRECTORY', '/p/c')])
     workspace_path_3 = _get_workspacepathobject([])
 
@@ -275,29 +282,30 @@ def test__list_tests_recursively__1test1dir1dir__1_test(mocker):
 
     tests = nutter.list_tests("/", True)
 
-    expected = [TestNotebook('test_1', '/test_1')]
+    expected = [TestNotebook('test_1', '/test_1'), TestNotebook('2_test', '/2_test')]
+
     assert expected == tests
     assert nutter.dbclient.list_objects.call_count == 3
 
-def test__list_suffix_tests_recursively__1test1dir1dir__1_test(mocker):
-    nutter = _get_nutter(mocker)
-    dbapi_client = _get_client(mocker)
-    nutter.dbclient = dbapi_client
-    mocker.patch.object(nutter.dbclient, 'list_objects')
+# def test__list_suffix_tests_recursively__1test1dir1dir__1_test(mocker):
+#     nutter = _get_nutter(mocker)
+#     dbapi_client = _get_client(mocker)
+#     nutter.dbclient = dbapi_client
+#     mocker.patch.object(nutter.dbclient, 'list_objects')
 
-    workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
-    workspace_path_2 = _get_workspacepathobject([('DIRECTORY', '/p/c')])
-    workspace_path_3 = _get_workspacepathobject([])
+#     workspace_path_1 = _get_workspacepathobject(
+#         [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
+#     workspace_path_2 = _get_workspacepathobject([('DIRECTORY', '/p/c')])
+#     workspace_path_3 = _get_workspacepathobject([])
 
-    nutter.dbclient.list_objects.side_effect = [
-        workspace_path_1, workspace_path_2, workspace_path_3]
+#     nutter.dbclient.list_objects.side_effect = [
+#         workspace_path_1, workspace_path_2, workspace_path_3]
 
-    tests = nutter.list_tests("/", True)
+#     tests = nutter.list_tests("/", True)
 
-    expected = [TestNotebook('1_test', '/1_test')]
-    assert expected == tests
-    assert nutter.dbclient.list_objects.call_count == 3
+#     expected = [TestNotebook('1_test', '/1_test')]
+#     assert expected == tests
+#     assert nutter.dbclient.list_objects.call_count == 3
 
 
 def test__list_tests__notest__empty_list(mocker):
@@ -313,7 +321,7 @@ def test__list_tests__notest__empty_list(mocker):
 
 
 
-def test__run_tests__onematch_two_tests___nutterstatusevents_testlisting_scheduling_execution_sequence_is_fired(mocker):
+def test__run_tests__twomatch_three_tests___nutterstatusevents_testlisting_scheduling_execution_sequence_is_fired(mocker):
     event_handler = TestEventHandler()
     nutter = _get_nutter(mocker, event_handler)
     test_results = TestResults()
@@ -323,7 +331,7 @@ def test__run_tests__onematch_two_tests___nutterstatusevents_testlisting_schedul
 
     nutter.dbclient = dbapi_client
     _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/test_my'), ('NOTEBOOK', '/test_abc')])
+        'NOTEBOOK', '/test_my'), ('NOTEBOOK', '/test_abc'), ('NOTEBOOK', '/my_test')])
 
     results = nutter.run_tests("/my*", "cluster")
 
@@ -336,52 +344,15 @@ def test__run_tests__onematch_two_tests___nutterstatusevents_testlisting_schedul
 
     status_event = event_handler.get_item()
     assert status_event.event == NutterStatusEvents.TestsListingResults
-    assert status_event.data == 2
+    assert status_event.data == 3
 
     status_event = event_handler.get_item()
     assert status_event.event == NutterStatusEvents.TestsListingFiltered
-    assert status_event.data == 1
+    assert status_event.data == 2
 
     status_event = event_handler.get_item()
     assert status_event.event == NutterStatusEvents.TestScheduling
     assert status_event.data == '/test_my'
-
-    status_event = event_handler.get_item()
-    assert status_event.event == NutterStatusEvents.TestExecuted
-    assert status_event.data.success
-
-    status_event = event_handler.get_item()
-    assert status_event.event == NutterStatusEvents.TestExecutionResult
-    assert status_event.data #True if success
-
-def test__run_suffix_tests__onematch_two_tests___nutterstatusevents_testlisting_scheduling_execution_sequence_is_fired(mocker):
-    event_handler = TestEventHandler()
-    nutter = _get_nutter(mocker, event_handler)
-    test_results = TestResults()
-    test_results.append(TestResult('case',True, 10,[]))
-    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', test_results.serialize())
-    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-
-    nutter.dbclient = dbapi_client
-    _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/abc_test')])
-
-    results = nutter.run_tests("/my*", "cluster")
-
-    status_event = event_handler.get_item()
-    assert status_event.event == NutterStatusEvents.TestExecutionRequest
-    assert status_event.data == '/my*'
-
-    status_event = event_handler.get_item()
-    assert status_event.event == NutterStatusEvents.TestsListing
-
-    status_event = event_handler.get_item()
-    assert status_event.event == NutterStatusEvents.TestsListingResults
-    assert status_event.data == 2
-
-    status_event = event_handler.get_item()
-    assert status_event.event == NutterStatusEvents.TestsListingFiltered
-    assert status_event.data == 1
 
     status_event = event_handler.get_item()
     assert status_event.event == NutterStatusEvents.TestScheduling
@@ -392,41 +363,92 @@ def test__run_suffix_tests__onematch_two_tests___nutterstatusevents_testlisting_
     assert status_event.data.success
 
     status_event = event_handler.get_item()
+    assert status_event.event == NutterStatusEvents.TestExecuted
+    assert status_event.data.success
+
+    status_event = event_handler.get_item()
     assert status_event.event == NutterStatusEvents.TestExecutionResult
     assert status_event.data #True if success
 
+# def test__run_suffix_tests__onematch_two_tests___nutterstatusevents_testlisting_scheduling_execution_sequence_is_fired(mocker):
+#     event_handler = TestEventHandler()
+#     nutter = _get_nutter(mocker, event_handler)
+#     test_results = TestResults()
+#     test_results.append(TestResult('case',True, 10,[]))
+#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', test_results.serialize())
+#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
 
-def test__run_tests__onematch__okay(mocker):
+#     nutter.dbclient = dbapi_client
+#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
+#         'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/abc_test')])
+
+#     results = nutter.run_tests("/my*", "cluster")
+
+#     status_event = event_handler.get_item()
+#     assert status_event.event == NutterStatusEvents.TestExecutionRequest
+#     assert status_event.data == '/my*'
+
+#     status_event = event_handler.get_item()
+#     assert status_event.event == NutterStatusEvents.TestsListing
+
+#     status_event = event_handler.get_item()
+#     assert status_event.event == NutterStatusEvents.TestsListingResults
+#     assert status_event.data == 2
+
+#     status_event = event_handler.get_item()
+#     assert status_event.event == NutterStatusEvents.TestsListingFiltered
+#     assert status_event.data == 1
+
+#     status_event = event_handler.get_item()
+#     assert status_event.event == NutterStatusEvents.TestScheduling
+#     assert status_event.data == '/my_test'
+
+#     status_event = event_handler.get_item()
+#     assert status_event.event == NutterStatusEvents.TestExecuted
+#     assert status_event.data.success
+
+#     status_event = event_handler.get_item()
+#     assert status_event.event == NutterStatusEvents.TestExecutionResult
+#     assert status_event.data #True if success
+
+
+def test__run_tests__twomatch__okay(mocker):
     nutter = _get_nutter(mocker)
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
 
     nutter.dbclient = dbapi_client
-    _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/test_my'), ('NOTEBOOK', '/my')])
+    _mock_dbclient_list_objects(mocker, dbapi_client, [
+        ('NOTEBOOK', '/test_my'),
+        ('NOTEBOOK', '/my'),
+        ('NOTEBOOK', '/my_test')])
 
     results = nutter.run_tests("/my*", "cluster")
 
-    assert len(results) == 1
+    assert len(results) == 2
+
     result = results[0]
     assert result.task_result_state == 'TERMINATED'
 
-def test__run_suffix_tests__onematch__okay(mocker):
-    nutter = _get_nutter(mocker)
-    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-
-    nutter.dbclient = dbapi_client
-    _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my')])
-
-    results = nutter.run_tests("/my*", "cluster")
-
-    assert len(results) == 1
-    result = results[0]
+    result = results[1]
     assert result.task_result_state == 'TERMINATED'
 
-def test__run_tests_recursively__1test1dir2test__3_tests(mocker):
+# def test__run_suffix_tests__onematch__okay(mocker):
+#     nutter = _get_nutter(mocker)
+#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+
+#     nutter.dbclient = dbapi_client
+#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
+#         'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my')])
+
+#     results = nutter.run_tests("/my*", "cluster")
+
+#     assert len(results) == 1
+#     result = results[0]
+#     assert result.task_result_state == 'TERMINATED'
+
+def test__run_tests_recursively__2test1dir3test__5_tests(mocker):
     nutter = _get_nutter(mocker)
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
@@ -435,36 +457,36 @@ def test__run_tests_recursively__1test1dir2test__3_tests(mocker):
     mocker.patch.object(nutter.dbclient, 'list_objects')
 
     workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/test_1'), ('DIRECTORY', '/p')])
+        [('NOTEBOOK', '/test_1'), ('NOTEBOOK', '/2_test'), ('DIRECTORY', '/p')])
     workspace_path_2 = _get_workspacepathobject(
-        [('NOTEBOOK', '/p/test_1'), ('NOTEBOOK', '/p/test_2')])
+        [('NOTEBOOK', '/p/test_1'), ('NOTEBOOK', '/p/test_2'), ('NOTEBOOK', '/p/3_test')])
 
     nutter.dbclient.list_objects.side_effect = [
         workspace_path_1, workspace_path_2]
 
     tests = nutter.run_tests('/','cluster', 120, 1, True)
-    assert len(tests) == 3
+    assert len(tests) == 5
 
-def test__run_suffix_tests_recursively__1test1dir2test__3_tests(mocker):
-    nutter = _get_nutter(mocker)
-    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-    nutter.dbclient = dbapi_client
+# def test__run_suffix_tests_recursively__1test1dir2test__3_tests(mocker):
+#     nutter = _get_nutter(mocker)
+#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+#     nutter.dbclient = dbapi_client
 
-    mocker.patch.object(nutter.dbclient, 'list_objects')
+#     mocker.patch.object(nutter.dbclient, 'list_objects')
 
-    workspace_path_1 = _get_workspacepathobject(
-        [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
-    workspace_path_2 = _get_workspacepathobject(
-        [('NOTEBOOK', '/p/test_1'), ('NOTEBOOK', '/p/2_test')])
+#     workspace_path_1 = _get_workspacepathobject(
+#         [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
+#     workspace_path_2 = _get_workspacepathobject(
+#         [('NOTEBOOK', '/p/test_1'), ('NOTEBOOK', '/p/2_test')])
 
-    nutter.dbclient.list_objects.side_effect = [
-        workspace_path_1, workspace_path_2]
+#     nutter.dbclient.list_objects.side_effect = [
+#         workspace_path_1, workspace_path_2]
 
-    tests = nutter.run_tests('/','cluster', 120, 1, True)
-    assert len(tests) == 3
+#     tests = nutter.run_tests('/','cluster', 120, 1, True)
+#     assert len(tests) == 3
 
-def test__run_tests_recursively__1dir1dir2test__2_tests(mocker):
+def test__run_tests_recursively__1dir1dir3test__3_tests(mocker):
     nutter = _get_nutter(mocker)
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
@@ -477,62 +499,62 @@ def test__run_tests_recursively__1dir1dir2test__2_tests(mocker):
     workspace_path_2 = _get_workspacepathobject(
         [('DIRECTORY', '/c')])
     workspace_path_3 = _get_workspacepathobject(
-        [('NOTEBOOK', '/p/c/test_1'), ('NOTEBOOK', '/p/c/test_2')])
+        [('NOTEBOOK', '/p/c/test_1'), ('NOTEBOOK', '/p/c/test_2'), ('NOTEBOOK', '/p/c/3_test')])
 
     nutter.dbclient.list_objects.side_effect = [
         workspace_path_1, workspace_path_2, workspace_path_3]
 
     tests = nutter.run_tests('/','cluster', 120, 1, True)
-    assert len(tests) == 2
+    assert len(tests) == 3
 
-def test__run_suffix_tests_recursively__1dir1dir2test__2_tests(mocker):
-    nutter = _get_nutter(mocker)
-    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-    nutter.dbclient = dbapi_client
+# def test__run_suffix_tests_recursively__1dir1dir2test__2_tests(mocker):
+    # nutter = _get_nutter(mocker)
+    # submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+    # dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+    # nutter.dbclient = dbapi_client
 
-    mocker.patch.object(nutter.dbclient, 'list_objects')
+    # mocker.patch.object(nutter.dbclient, 'list_objects')
 
-    workspace_path_1 = _get_workspacepathobject(
-        [('DIRECTORY', '/p')])
-    workspace_path_2 = _get_workspacepathobject(
-        [('DIRECTORY', '/c')])
-    workspace_path_3 = _get_workspacepathobject(
-        [('NOTEBOOK', '/p/c/1_test'), ('NOTEBOOK', '/p/c/2_test')])
+    # workspace_path_1 = _get_workspacepathobject(
+    #     [('DIRECTORY', '/p')])
+    # workspace_path_2 = _get_workspacepathobject(
+    #     [('DIRECTORY', '/c')])
+    # workspace_path_3 = _get_workspacepathobject(
+    #     [('NOTEBOOK', '/p/c/1_test'), ('NOTEBOOK', '/p/c/2_test')])
 
-    nutter.dbclient.list_objects.side_effect = [
-        workspace_path_1, workspace_path_2, workspace_path_3]
+    # nutter.dbclient.list_objects.side_effect = [
+    #     workspace_path_1, workspace_path_2, workspace_path_3]
 
-    tests = nutter.run_tests('/','cluster', 120, 1, True)
-    assert len(tests) == 2
+    # tests = nutter.run_tests('/','cluster', 120, 1, True)
+    # assert len(tests) == 2
 
-def test__run_tests__onematch_suffix_is_uppercase__okay(mocker):
+def test__run_tests__twomatch__is_uppercase__okay(mocker):
     nutter = _get_nutter(mocker)
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
 
     nutter.dbclient = dbapi_client
     _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/TEST_my'), ('NOTEBOOK', '/my')])
+        'NOTEBOOK', '/TEST_my'), ('NOTEBOOK', '/my'), ('NOTEBOOK', '/my_TEST')])
 
     results = nutter.run_tests("/my*", "cluster")
 
-    assert len(results) == 1
+    assert len(results) == 2
     assert results[0].task_result_state == 'TERMINATED'
 
-def test__run_suffix_tests__onematch_suffix_is_uppercase__okay(mocker):
-    nutter = _get_nutter(mocker)
-    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+# def test__run_suffix_tests__onematch_suffix_is_uppercase__okay(mocker):
+#     nutter = _get_nutter(mocker)
+#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
 
-    nutter.dbclient = dbapi_client
-    _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/my_TEST'), ('NOTEBOOK', '/my')])
+#     nutter.dbclient = dbapi_client
+#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
+#         'NOTEBOOK', '/my_TEST'), ('NOTEBOOK', '/my')])
 
-    results = nutter.run_tests("/my*", "cluster")
+#     results = nutter.run_tests("/my*", "cluster")
 
-    assert len(results) == 1
-    assert results[0].task_result_state == 'TERMINATED'
+#     assert len(results) == 1
+#     assert results[0].task_result_state == 'TERMINATED'
 
 
 def test__run_tests__nomatch_case_sensitive__okay(mocker):
@@ -542,55 +564,56 @@ def test__run_tests__nomatch_case_sensitive__okay(mocker):
 
     nutter.dbclient = dbapi_client
     _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/test_MY'), ('NOTEBOOK', '/my')])
+        'NOTEBOOK', '/test_MY'), ('NOTEBOOK', '/my'), ('NOTEBOOK', '/MY_test')])
 
     results = nutter.run_tests("/my*", "cluster")
 
     assert len(results) == 0
 
-def test__run_suffix_tests__nomatch_case_sensitive__okay(mocker):
-    nutter = _get_nutter(mocker)
+# def test__run_suffix_tests__nomatch_case_sensitive__okay(mocker):
+#     nutter = _get_nutter(mocker)
+#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+
+#     nutter.dbclient = dbapi_client
+#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
+#         'NOTEBOOK', '/MY_test'), ('NOTEBOOK', '/my')])
+
+#     results = nutter.run_tests("/my*", "cluster")
+
+#     assert len(results) == 0
+
+def test__run_tests__fourmatches_with_pattern__okay(mocker):
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
 
-    nutter.dbclient = dbapi_client
-    _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/MY_test'), ('NOTEBOOK', '/my')])
-
-    results = nutter.run_tests("/my*", "cluster")
-
-    assert len(results) == 0
-
-
-def test__run_tests__twomatches_with_pattern__okay(mocker):
-    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-
     nutter = _get_nutter(mocker)
     nutter.dbclient = dbapi_client
     _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/test_my'), ('NOTEBOOK', '/test_my2')])
+        'NOTEBOOK', '/test_my'), ('NOTEBOOK', '/test_my2'), ('NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my3_test')])
 
     results = nutter.run_tests("/my*", "cluster")
 
-    assert len(results) == 2
+    assert len(results) == 4
     assert results[0].task_result_state == 'TERMINATED'
     assert results[1].task_result_state == 'TERMINATED'
+    assert results[2].task_result_state == 'TERMINATED'
+    assert results[3].task_result_state == 'TERMINATED'
 
-def test__run_suffix_tests__twomatches_with_pattern__okay(mocker):
-    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+# def test__run_suffix_tests__twomatches_with_pattern__okay(mocker):
+#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
 
-    nutter = _get_nutter(mocker)
-    nutter.dbclient = dbapi_client
-    _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my2_test')])
+#     nutter = _get_nutter(mocker)
+#     nutter.dbclient = dbapi_client
+#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
+#         'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my2_test')])
 
-    results = nutter.run_tests("/my*", "cluster")
+#     results = nutter.run_tests("/my*", "cluster")
 
-    assert len(results) == 2
-    assert results[0].task_result_state == 'TERMINATED'
-    assert results[1].task_result_state == 'TERMINATED'
+#     assert len(results) == 2
+#     assert results[0].task_result_state == 'TERMINATED'
+#     assert results[1].task_result_state == 'TERMINATED'
 
 def test__run_tests__with_invalid_pattern__valueerror(mocker):
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
@@ -610,23 +633,23 @@ def test__run_tests__nomatches__okay(mocker):
     nutter = _get_nutter(mocker)
     nutter.dbclient = dbapi_client
     _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/test_my'), ('NOTEBOOK', '/test_my2')])
+        'NOTEBOOK', '/test_my'), ('NOTEBOOK', '/test_my2'), ('NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my3_test')])
 
     results = nutter.run_tests("/abc*", "cluster")
 
     assert len(results) == 0
 
-def test__run_suffix_tests__nomatches__okay(mocker):
-    submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-    dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-    nutter = _get_nutter(mocker)
-    nutter.dbclient = dbapi_client
-    _mock_dbclient_list_objects(mocker, dbapi_client, [(
-        'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my2_test')])
+# def test__run_suffix_tests__nomatches__okay(mocker):
+#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
+#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
+#     nutter = _get_nutter(mocker)
+#     nutter.dbclient = dbapi_client
+#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
+#         'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my2_test')])
 
-    results = nutter.run_tests("/abc*", "cluster")
+#     results = nutter.run_tests("/abc*", "cluster")
 
-    assert len(results) == 0
+#     assert len(results) == 0
 
 
 def test__to_testresults__none_output__none(mocker):

--- a/tests/nutter/test_api.py
+++ b/tests/nutter/test_api.py
@@ -49,23 +49,6 @@ def test__list_tests__twotest__okay(mocker):
     assert tests[0] == TestNotebook('test_mynotebook', '/test_mynotebook')
     assert tests[1] == TestNotebook('mynotebook_test', '/mynotebook_test')
 
-# def test__list_suffix_tests__onetest__okay(mocker):
-
-#     nutter = _get_nutter(mocker)
-#     dbapi_client = _get_client(mocker)
-#     nutter.dbclient = dbapi_client
-#     mocker.patch.object(nutter.dbclient, 'list_objects')
-
-#     workspace_path_1 = _get_workspacepathobject(
-#         [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/mynotebook_test')])
-
-#     nutter.dbclient.list_objects.return_value = workspace_path_1
-
-#     tests = nutter.list_tests("/")
-
-#     assert len(tests) == 1
-#     assert tests[0] == TestNotebook('mynotebook_test', '/mynotebook_test')
-
 def test__list_tests__twotest_in_folder__okay(mocker):
 
     nutter = _get_nutter(mocker)
@@ -85,24 +68,6 @@ def test__list_tests__twotest_in_folder__okay(mocker):
         'test_mynotebook', '/folder/test_mynotebook')
     assert tests[1] == TestNotebook(
         'mynotebook_test', '/folder/mynotebook_test')
-
-# def test__list_suffix_tests__onetest_in_folder__okay(mocker):
-
-#     nutter = _get_nutter(mocker)
-#     dbapi_client = _get_client(mocker)
-#     nutter.dbclient = dbapi_client
-#     mocker.patch.object(nutter.dbclient, 'list_objects')
-
-#     workspace_path_1 = _get_workspacepathobject(
-#         [('NOTEBOOK', '/folder/mynotebook'), ('NOTEBOOK', '/folder/mynotebook_test')])
-
-#     nutter.dbclient.list_objects.return_value = workspace_path_1
-
-#     tests = nutter.list_tests("/folder")
-
-#     assert len(tests) == 1
-#     assert tests[0] == TestNotebook(
-#         'mynotebook_test', '/folder/mynotebook_test')
 
 @pytest.mark.skip('No longer needed')
 def test__list_tests__response_without_root_object__okay(mocker):
@@ -141,24 +106,6 @@ def test__list_tests__twotest_uppercase_name__okay(mocker):
 
     assert len(tests) == 2
     assert tests == [TestNotebook('TEST_mynote', '/TEST_mynote'), TestNotebook('mynote_TEST', '/mynote_TEST')]
-
-# def test__list_suffix_tests__onetest_uppercase_name__okay(mocker):
-
-#     nutter = _get_nutter(mocker)
-#     dbapi_client = _get_client(mocker)
-#     nutter.dbclient = dbapi_client
-#     mocker.patch.object(nutter.dbclient, 'list_objects')
-
-#     workspace_path_1 = _get_workspacepathobject(
-#         [('NOTEBOOK', '/mynotebook'), ('NOTEBOOK', '/mynote_TEST')])
-
-#     nutter.dbclient.list_objects.return_value = workspace_path_1
-
-#     tests = nutter.list_tests("/")
-
-#     assert len(tests) == 1
-#     assert tests == [TestNotebook('mynote_TEST', '/mynote_TEST')]
-
 
 def test__list_tests__nutterstatusevents_testlisting_sequence_is_fired(mocker):
     event_handler = TestEventHandler()
@@ -200,27 +147,6 @@ def test__list_tests_recursively__1test1dir2test__3_tests(mocker):
     assert expected == tests
     assert nutter.dbclient.list_objects.call_count == 2
 
-# def test__list_suffix_tests_recursively__1test1dir1test__2_tests(mocker):
-#     nutter = _get_nutter(mocker)
-#     dbapi_client = _get_client(mocker)
-#     nutter.dbclient = dbapi_client
-#     mocker.patch.object(nutter.dbclient, 'list_objects')
-
-#     workspace_path_1 = _get_workspacepathobject(
-#         [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
-#     workspace_path_2 = _get_workspacepathobject([('NOTEBOOK', '/p/1_test')])
-
-#     nutter.dbclient.list_objects.side_effect = [
-#         workspace_path_1, workspace_path_2]
-
-#     tests = nutter.list_tests("/", True)
-
-#     expected = [TestNotebook('1_test', '/1_test'),
-#                 TestNotebook('1_test', '/p/1_test')]
-#     assert expected == tests
-#     assert nutter.dbclient.list_objects.call_count == 2
-
-
 def test__list_tests_recursively__2test1dir2test__4_tests(mocker):
     nutter = _get_nutter(mocker)
     dbapi_client = _get_client(mocker)
@@ -245,27 +171,6 @@ def test__list_tests_recursively__2test1dir2test__4_tests(mocker):
     assert expected == tests
     assert nutter.dbclient.list_objects.call_count == 2
 
-# def test__list_suffix_tests_recursively__1test1dir2test__3_tests(mocker):
-#     nutter = _get_nutter(mocker)
-#     dbapi_client = _get_client(mocker)
-#     nutter.dbclient = dbapi_client
-#     mocker.patch.object(nutter.dbclient, 'list_objects')
-
-#     workspace_path_1 = _get_workspacepathobject(
-#         [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
-#     workspace_path_2 = _get_workspacepathobject(
-#         [('NOTEBOOK', '/p/1_test'), ('NOTEBOOK', '/p/2_test')])
-
-#     nutter.dbclient.list_objects.side_effect = [
-#         workspace_path_1, workspace_path_2]
-
-#     tests = nutter.list_tests("/", True)
-#     expected = [TestNotebook('1_test', '/1_test'), TestNotebook('1_test',
-#                                                                 '/p/1_test'), TestNotebook('2_test', '/p/2_test')]
-#     assert expected == tests
-#     assert nutter.dbclient.list_objects.call_count == 2
-
-
 def test__list_tests_recursively__1test1test1dir1dir__2_test(mocker):
     nutter = _get_nutter(mocker)
     dbapi_client = _get_client(mocker)
@@ -286,27 +191,6 @@ def test__list_tests_recursively__1test1test1dir1dir__2_test(mocker):
 
     assert expected == tests
     assert nutter.dbclient.list_objects.call_count == 3
-
-# def test__list_suffix_tests_recursively__1test1dir1dir__1_test(mocker):
-#     nutter = _get_nutter(mocker)
-#     dbapi_client = _get_client(mocker)
-#     nutter.dbclient = dbapi_client
-#     mocker.patch.object(nutter.dbclient, 'list_objects')
-
-#     workspace_path_1 = _get_workspacepathobject(
-#         [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
-#     workspace_path_2 = _get_workspacepathobject([('DIRECTORY', '/p/c')])
-#     workspace_path_3 = _get_workspacepathobject([])
-
-#     nutter.dbclient.list_objects.side_effect = [
-#         workspace_path_1, workspace_path_2, workspace_path_3]
-
-#     tests = nutter.list_tests("/", True)
-
-#     expected = [TestNotebook('1_test', '/1_test')]
-#     assert expected == tests
-#     assert nutter.dbclient.list_objects.call_count == 3
-
 
 def test__list_tests__notest__empty_list(mocker):
     nutter = _get_nutter(mocker)
@@ -370,48 +254,6 @@ def test__run_tests__twomatch_three_tests___nutterstatusevents_testlisting_sched
     assert status_event.event == NutterStatusEvents.TestExecutionResult
     assert status_event.data #True if success
 
-# def test__run_suffix_tests__onematch_two_tests___nutterstatusevents_testlisting_scheduling_execution_sequence_is_fired(mocker):
-#     event_handler = TestEventHandler()
-#     nutter = _get_nutter(mocker, event_handler)
-#     test_results = TestResults()
-#     test_results.append(TestResult('case',True, 10,[]))
-#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', test_results.serialize())
-#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-
-#     nutter.dbclient = dbapi_client
-#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
-#         'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/abc_test')])
-
-#     results = nutter.run_tests("/my*", "cluster")
-
-#     status_event = event_handler.get_item()
-#     assert status_event.event == NutterStatusEvents.TestExecutionRequest
-#     assert status_event.data == '/my*'
-
-#     status_event = event_handler.get_item()
-#     assert status_event.event == NutterStatusEvents.TestsListing
-
-#     status_event = event_handler.get_item()
-#     assert status_event.event == NutterStatusEvents.TestsListingResults
-#     assert status_event.data == 2
-
-#     status_event = event_handler.get_item()
-#     assert status_event.event == NutterStatusEvents.TestsListingFiltered
-#     assert status_event.data == 1
-
-#     status_event = event_handler.get_item()
-#     assert status_event.event == NutterStatusEvents.TestScheduling
-#     assert status_event.data == '/my_test'
-
-#     status_event = event_handler.get_item()
-#     assert status_event.event == NutterStatusEvents.TestExecuted
-#     assert status_event.data.success
-
-#     status_event = event_handler.get_item()
-#     assert status_event.event == NutterStatusEvents.TestExecutionResult
-#     assert status_event.data #True if success
-
-
 def test__run_tests__twomatch__okay(mocker):
     nutter = _get_nutter(mocker)
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
@@ -433,21 +275,6 @@ def test__run_tests__twomatch__okay(mocker):
     result = results[1]
     assert result.task_result_state == 'TERMINATED'
 
-# def test__run_suffix_tests__onematch__okay(mocker):
-#     nutter = _get_nutter(mocker)
-#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-
-#     nutter.dbclient = dbapi_client
-#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
-#         'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my')])
-
-#     results = nutter.run_tests("/my*", "cluster")
-
-#     assert len(results) == 1
-#     result = results[0]
-#     assert result.task_result_state == 'TERMINATED'
-
 def test__run_tests_recursively__2test1dir3test__5_tests(mocker):
     nutter = _get_nutter(mocker)
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
@@ -466,25 +293,6 @@ def test__run_tests_recursively__2test1dir3test__5_tests(mocker):
 
     tests = nutter.run_tests('/','cluster', 120, 1, True)
     assert len(tests) == 5
-
-# def test__run_suffix_tests_recursively__1test1dir2test__3_tests(mocker):
-#     nutter = _get_nutter(mocker)
-#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-#     nutter.dbclient = dbapi_client
-
-#     mocker.patch.object(nutter.dbclient, 'list_objects')
-
-#     workspace_path_1 = _get_workspacepathobject(
-#         [('NOTEBOOK', '/1_test'), ('DIRECTORY', '/p')])
-#     workspace_path_2 = _get_workspacepathobject(
-#         [('NOTEBOOK', '/p/test_1'), ('NOTEBOOK', '/p/2_test')])
-
-#     nutter.dbclient.list_objects.side_effect = [
-#         workspace_path_1, workspace_path_2]
-
-#     tests = nutter.run_tests('/','cluster', 120, 1, True)
-#     assert len(tests) == 3
 
 def test__run_tests_recursively__1dir1dir3test__3_tests(mocker):
     nutter = _get_nutter(mocker)
@@ -507,27 +315,6 @@ def test__run_tests_recursively__1dir1dir3test__3_tests(mocker):
     tests = nutter.run_tests('/','cluster', 120, 1, True)
     assert len(tests) == 3
 
-# def test__run_suffix_tests_recursively__1dir1dir2test__2_tests(mocker):
-    # nutter = _get_nutter(mocker)
-    # submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-    # dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-    # nutter.dbclient = dbapi_client
-
-    # mocker.patch.object(nutter.dbclient, 'list_objects')
-
-    # workspace_path_1 = _get_workspacepathobject(
-    #     [('DIRECTORY', '/p')])
-    # workspace_path_2 = _get_workspacepathobject(
-    #     [('DIRECTORY', '/c')])
-    # workspace_path_3 = _get_workspacepathobject(
-    #     [('NOTEBOOK', '/p/c/1_test'), ('NOTEBOOK', '/p/c/2_test')])
-
-    # nutter.dbclient.list_objects.side_effect = [
-    #     workspace_path_1, workspace_path_2, workspace_path_3]
-
-    # tests = nutter.run_tests('/','cluster', 120, 1, True)
-    # assert len(tests) == 2
-
 def test__run_tests__twomatch__is_uppercase__okay(mocker):
     nutter = _get_nutter(mocker)
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
@@ -542,21 +329,6 @@ def test__run_tests__twomatch__is_uppercase__okay(mocker):
     assert len(results) == 2
     assert results[0].task_result_state == 'TERMINATED'
 
-# def test__run_suffix_tests__onematch_suffix_is_uppercase__okay(mocker):
-#     nutter = _get_nutter(mocker)
-#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-
-#     nutter.dbclient = dbapi_client
-#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
-#         'NOTEBOOK', '/my_TEST'), ('NOTEBOOK', '/my')])
-
-#     results = nutter.run_tests("/my*", "cluster")
-
-#     assert len(results) == 1
-#     assert results[0].task_result_state == 'TERMINATED'
-
-
 def test__run_tests__nomatch_case_sensitive__okay(mocker):
     nutter = _get_nutter(mocker)
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
@@ -569,19 +341,6 @@ def test__run_tests__nomatch_case_sensitive__okay(mocker):
     results = nutter.run_tests("/my*", "cluster")
 
     assert len(results) == 0
-
-# def test__run_suffix_tests__nomatch_case_sensitive__okay(mocker):
-#     nutter = _get_nutter(mocker)
-#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-
-#     nutter.dbclient = dbapi_client
-#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
-#         'NOTEBOOK', '/MY_test'), ('NOTEBOOK', '/my')])
-
-#     results = nutter.run_tests("/my*", "cluster")
-
-#     assert len(results) == 0
 
 def test__run_tests__fourmatches_with_pattern__okay(mocker):
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
@@ -599,21 +358,6 @@ def test__run_tests__fourmatches_with_pattern__okay(mocker):
     assert results[1].task_result_state == 'TERMINATED'
     assert results[2].task_result_state == 'TERMINATED'
     assert results[3].task_result_state == 'TERMINATED'
-
-# def test__run_suffix_tests__twomatches_with_pattern__okay(mocker):
-#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-
-#     nutter = _get_nutter(mocker)
-#     nutter.dbclient = dbapi_client
-#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
-#         'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my2_test')])
-
-#     results = nutter.run_tests("/my*", "cluster")
-
-#     assert len(results) == 2
-#     assert results[0].task_result_state == 'TERMINATED'
-#     assert results[1].task_result_state == 'TERMINATED'
 
 def test__run_tests__with_invalid_pattern__valueerror(mocker):
     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
@@ -638,19 +382,6 @@ def test__run_tests__nomatches__okay(mocker):
     results = nutter.run_tests("/abc*", "cluster")
 
     assert len(results) == 0
-
-# def test__run_suffix_tests__nomatches__okay(mocker):
-#     submit_response = _get_submit_run_response('SUCCESS', 'TERMINATED', '')
-#     dbapi_client = _get_client_for_execute_notebook(mocker, submit_response)
-#     nutter = _get_nutter(mocker)
-#     nutter.dbclient = dbapi_client
-#     _mock_dbclient_list_objects(mocker, dbapi_client, [(
-#         'NOTEBOOK', '/my_test'), ('NOTEBOOK', '/my2_test')])
-
-#     results = nutter.run_tests("/abc*", "cluster")
-
-#     assert len(results) == 0
-
 
 def test__to_testresults__none_output__none(mocker):
     output = None


### PR DESCRIPTION
# Summary
Make tests with '_test suffix' discoverable. Unit tests were updated in test_api to include suffix checks. This feature was requested in issue #43 

Local testing
![image](https://user-images.githubusercontent.com/12203314/84732025-70533580-af4f-11ea-87b9-57f96e91b4f7.png)

Note: Not sure why the commits are made under user "qnuw", but the commits are from me.