### PR TITLE
Round test duration seconds to nearest millisecond (3 decimal places)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Notebook: (local) - Lifecycle State: N/A, Result: N/A
 ============================================================
 PASSING TESTS
 ------------------------------------------------------------
-test_name (19.43149897100011 seconds)
+test_name (19.431 seconds)
 
 
 ============================================================
@@ -246,8 +246,8 @@ Run Page URL: N/A
 ============================================================
 PASSING TESTS
 ------------------------------------------------------------
-country_data_is_inserted (11.446587234000617 seconds)
-customer_data_is_inserted (11.53276599000128 seconds)
+country_data_is_inserted (11.447 seconds)
+customer_data_is_inserted (11.533 seconds)
 
 
 ============================================================

--- a/common/resultsview.py
+++ b/common/resultsview.py
@@ -222,7 +222,7 @@ class TestCaseResultView(ResultsView):
     def get_view(self):
         sw = StringWriter()
 
-        time = '{} seconds'.format(self.execution_time)
+        time = '{:.3f} seconds'.format(self.execution_time)
         sw.write_line('{} ({})'.format(self.test_case, time))
 
         if (self.passed):


### PR DESCRIPTION
Currently, the test duration is printed with 14 decimal places, like this:

test_name (2.43199897100011 seconds)

This PR is to round the test duration to the nearest millisecond (3 decimal places), to make it more readable and practical, like this:

test_name (2.432 seconds)